### PR TITLE
解决跨平台进行生成/发布操作时缺少必要的运行时文件问题

### DIFF
--- a/GreenOnions.BotMain/GreenOnions.BotMain.csproj
+++ b/GreenOnions.BotMain/GreenOnions.BotMain.csproj
@@ -22,6 +22,15 @@
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(RuntimeIdentifier)' == 'win-x86' or '$(RuntimeIdentifier)' == 'win-x64'">
+    <PackageReference Include="Mirai-CSharp.NativeAssets.Win32" Version="1.0.2"/>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(RuntimeIdentifier)' == 'linux-x64'">
+    <PackageReference Include="Mirai-CSharp.NativeAssets.Linux" Version="1.0.2"/>
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="2.80.3"/>
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\GreenOnions.ForgeMessage\GreenOnions.ForgeMessage.csproj" />
     <ProjectReference Include="..\GreenOnions.Help\GreenOnions.Help.csproj" />


### PR DESCRIPTION
翻了一小时google没找到能在我的包里边让msbuild带上所需运行时的方法
只能在用户端这边先行引用必要的运行时了
顺带一提的是, 不用发布为Self-Contained，走Framework-dependent就行了